### PR TITLE
Added support for running BART through ssh

### DIFF
--- a/src/mcplots.py
+++ b/src/mcplots.py
@@ -51,6 +51,7 @@
 import sys, os
 import numpy as np
 import matplotlib as mpl
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 
 sys.path.append(os.path.dirname(os.path.realpath(__file__))+'/cfuncs/lib')


### PR DESCRIPTION
One line fix that allows the creation of plots when DISPLAY is not set. Allows BART to be run over ssh / tmux.