### PR TITLE
Implemented cap to avoid running with more processes than CPUs.

### DIFF
--- a/MCcubed/VERSION.py
+++ b/MCcubed/VERSION.py
@@ -4,4 +4,4 @@
 # MC3 Version:
 MC3_VER =  2  # Major version
 MC3_MIN =  1  # Minor version
-MC3_REV =  2  # Revision
+MC3_REV =  3  # Revision

--- a/MCcubed/mc/mcmc.py
+++ b/MCcubed/mc/mcmc.py
@@ -167,6 +167,15 @@ def mcmc(data,         uncert=None,      func=None,     indparams=[],
              "and path names.", log)
 
   nproc = nchains
+  # Cap the number of processors:
+  if nproc >= mpr.cpu_count():
+    mu.warning("The number of requested CPUs ({:d}) is >= than the number "
+      "of available CPUs ({:d}).  Enforced nproc to {:d}.".format(nproc,
+             mpr.cpu_count(), mpr.cpu_count()-1), log)
+    nproc = mpr.cpu_count() - 1
+    # Re-set number of chains as well:
+    nchains = nproc
+
   nparams = len(params)  # Number of model params
   ndata   = len(data)    # Number of data values
   # Set default uncertainties:


### PR DESCRIPTION
MC3 will use at most Ncpus-1 chains (because one CPU is necessary for
the main hub).
Bumped MC3 to version 2.1.3.