### PR TITLE
Added exception in snooker update when Z equals the current chain

### DIFF
--- a/MCcubed/VERSION.py
+++ b/MCcubed/VERSION.py
@@ -4,4 +4,4 @@
 # MC3 Version:
 MC3_VER =  2  # Major version
 MC3_MIN =  2  # Minor version
-MC3_REV =  0  # Revision
+MC3_REV =  1  # Revision

--- a/MCcubed/mc/chain.py
+++ b/MCcubed/mc/chain.py
@@ -178,7 +178,10 @@ class Chain(mp.Process):
           dz = self.freepars[self.ID] - z
           zp1 = np.dot(self.Z[iR1], dz)
           zp2 = np.dot(self.Z[iR2], dz)
-          jump = np.random.uniform(1.2, 2.2) * (zp1-zp2) * dz/np.dot(dz,dz)
+          if np.all(z == self.freepars[self.ID]):  # Do not project:
+            jump = np.random.uniform(1.2, 2.2) * (self.Z[iR2]-self.Z[iR1])
+          else:
+            jump = np.random.uniform(1.2, 2.2) * (zp1-zp2) * dz/np.dot(dz,dz)
         else: # Z update:
           jump = gamma*(self.Z[iR1] - self.Z[iR2]) + gamma2*normal
       elif self.walk == "mrw":


### PR DESCRIPTION
state (which entails a null dot product and further NaNs).  Patched
with a non-Z-projected jump given by the diff of iR1 and iR2.