### PR TITLE
Fix for output display in Python 3

### DIFF
--- a/MCcubed/mc/mcmc.py
+++ b/MCcubed/mc/mcmc.py
@@ -568,7 +568,7 @@ def mcmc(data,         uncert=None,   func=None,      indparams=[],
   mu.msg(1, "Number of parallel chains:          {:{}d}".
              format(nchains,  fmtlen), log, 2)
   mu.msg(1, "Average iterations per chain:       {:{}d}".
-             format(nsample/nchains, fmtlen), log, 2)
+             format(nsample//nchains, fmtlen), log, 2)
   mu.msg(1, "Burned-in iterations per chain:     {:{}d}".
              format(burnin,   fmtlen), log, 2)
   mu.msg(1, "Thinning factor:                    {:{}d}".


### PR DESCRIPTION
Without implicit integer division of Python 2, this tries to output a float as an integer and crashes. As I understand it, the result of the division will always be an integer in the mathematical sense, so forcing integer division should be fine.