### PR TITLE
MPI-snooker updated to ensure hsize > nchains

### DIFF
--- a/MCcubed/mc/mcmc.py
+++ b/MCcubed/mc/mcmc.py
@@ -213,6 +213,10 @@ def mcmc(data,            uncert=None,      func=None,      indparams=[],
              "the number of iterations per chain ({:d}).".
              format(burnin, chainsize), log)
 
+  # Ensure that hsize is > nchains
+  if walk=='snooker' and hsize < nchains:
+    hsize = nchains + 1
+
   # Intermediate steps to run GR test and print progress report:
   intsteps   = chainsize / 10
 


### PR DESCRIPTION
Quality-of-life improvement so that the user does not have to specify hsize.