### PR TITLE
Updated CR to allow any number of disconnected regions and any number of percentiles

### DIFF
--- a/MCcubed/mc/driver.py
+++ b/MCcubed/mc/driver.py
@@ -30,8 +30,8 @@ def mcmc(data=None,     uncert=None,     func=None,      indparams=None,
          plots=None,    ioff=None,       showbp=None,
          savefile=None, savemodel=None,  resume=None,
          rms=None,      log=None,        pnames=None,    texnames=None,
-         full_output=None, chireturn=None,
-         cfile=None,         parname=None):
+         full_output=None, chireturn=None, percentile=None,
+         cfile=None,    parname=None):
   """
   MCMC driver routine to execute a Markov-chain Monte Carlo run.
 
@@ -143,8 +143,6 @@ def mcmc(data=None,     uncert=None,     func=None,      indparams=None,
      If True, calculate the RMS of data-bestmodel.
   log: String or Log object.
      Filename to store screen outputs.
-  cfile: String
-     Configuration file name.
   pnames: 1D string ndarray
      List of parameter names (including fixed and shared parameters)
      to display on output screen and figures.  See also texnames.
@@ -153,11 +151,16 @@ def mcmc(data=None,     uncert=None,     func=None,      indparams=None,
   texnames: 1D string iterable
      Parameter names for figures, which may use latex syntax.
      If not defined, default to pnames.
-  parname: 1D string ndarray
-     Deprecated.  Use pnames instead.
   full_output:  Bool
      If True, return the full posterior sample, including the burned-in
      iterations.
+  chireturn: FINDME
+  percentile: list, floats
+     Percentile(s) to report credible region(s).
+  cfile: String
+     Configuration file name.
+  parname: 1D string ndarray
+     Deprecated.  Use pnames instead.
 
   Returns
   -------
@@ -433,6 +436,9 @@ def parse():
                      help="If True, return chi-squared, red. chi-squared,"
                           "the chi-squared rescaling factor, and the BIC"
                           " [default: %(default)s]")
+  group.add_argument("--percentile", dest="percentile", action="store", 
+                     type=mu.parray, default=[0.6827, 0.9545], 
+                     help="Percentile(s) to report credible region(s).")
   group.add_argument("--parname",   dest="parname", action="store",
                      type=mu.parray, default=None,
                      help="Deprecated, see pnames.")

--- a/MCcubed/mc/mcmc.py
+++ b/MCcubed/mc/mcmc.py
@@ -39,7 +39,7 @@ def mcmc(data,          uncert=None,    func=None,      indparams=[],
          plots=False,   ioff=False,     showbp=True,
          savefile=None, savemodel=None, resume=False,
          rms=False,     log=None,       pnames=None,    texnames=None,
-         full_output=False, chireturn=False,
+         full_output=False, chireturn=False, percentile=[0.6827, 0.9545], 
          parname=None):
   """
   This beautiful piece of code runs a Markov-chain Monte Carlo algorithm.
@@ -155,6 +155,8 @@ def mcmc(data,          uncert=None,    func=None,      indparams=[],
      iterations.
   chireturn: Bool
      If True, include chi-squared statistics in the return.
+  percentile: list, floats
+     Percentile(s) to report credible region(s).
   parname: 1D string ndarray
      Deprecated, use pnames.
 
@@ -162,12 +164,13 @@ def mcmc(data,          uncert=None,    func=None,      indparams=[],
   -------
   bestp: 1D ndarray
      Array of the best-fitting parameters (including fixed and shared).
-  CRlo:  1D ndarray
-     The lower boundary of the marginal 68%-highest posterior density
-     (the credible region) for each parameter, with respect to bestp.
-  CRhi:  1D ndarray
-     The upper boundary of the marginal 68%-highest posterior density
-     (the credible region) for each parameter, with respect to bestp.
+  creg: list of strings
+     The posterior credible regions corresponding to the percentiles specified 
+     by `percentile`. Format is e.g., '(lo_1, hi_1) U (lo_2, hi_2)' for a CR 
+     composed of two disconnected regions.
+     creg[i]    gives the i-th parameter's      CRs.
+     creg[i][j] gives the i-th parameter's j-th CR, corresponding to the j-th 
+                `percentile` value.
   stdp: 1D ndarray
      Array of the best-fitting parameter uncertainties, calculated as the
      standard deviation of the marginalized, thinned, burned-in posterior.
@@ -612,19 +615,15 @@ def mcmc(data,          uncert=None,    func=None,      indparams=[],
            format(numaccept.value*100.0/nsample), indent=2)
 
   # Compute the credible region for each parameter:
-  CRlo = np.zeros(nparams)
-  CRhi = np.zeros(nparams)
+  CR   = [] # Holds boundaries of all regions making up the CRs
+  creg = [] # Holds a string representation, '[lo_1, hi_1] U [lo_2, hi_2] U ...'
   pdf  = []
   xpdf = []
   for i in range(nfree):
-    PDF, Xpdf, HPDmin = mu.credregion(posterior[:,i])
+    PDF, XPDF, regions = mu.credregion(posterior[:,i], percentile)
     pdf.append(PDF)
-    xpdf.append(Xpdf)
-    CRlo[ifree[i]] = np.amin(Xpdf[PDF>HPDmin])
-    CRhi[ifree[i]] = np.amax(Xpdf[PDF>HPDmin])
-  # CR relative to the best-fitting value:
-  CRlo[ifree] -= bestp[ifree]
-  CRhi[ifree] -= bestp[ifree]
+    xpdf.append(XPDF)
+    CR.append(regions)
 
   # Get the mean and standard deviation from the posterior:
   meanp = np.zeros(nparams, np.double) # Parameters mean
@@ -635,27 +634,74 @@ def mcmc(data,          uncert=None,    func=None,      indparams=[],
     bestp[s] = bestp[-int(stepsize[s])-1]
     meanp[s] = meanp[-int(stepsize[s])-1]
     stdp [s] = stdp [-int(stepsize[s])-1]
-    CRlo [s] = CRlo [-int(stepsize[s])-1]
-    CRhi [s] = CRhi [-int(stepsize[s])-1]
 
-  log.msg("\nParam name     Best fit   Lo HPD CR   Hi HPD CR        Mean    Std dev       S/N"
-          "\n----------- ----------------------------------- ---------------------- ---------", width=80)
+  log.msg("\nParam name     Best fit        Mean    Std dev       S/N"
+          "\n----------- ------------ ---------------------- ---------", width=80)
   for i in range(nparams):
     snr  = "{:.1f}".   format(np.abs(bestp[i])/stdp[i])
     mean = "{: 11.4e}".format(meanp[i])
-    lo   = "{: 11.4e}".format(CRlo[i])
-    hi   = "{: 11.4e}".format(CRhi[i])
     if   i in ifree:  # Free-fitting value
-      pass
+      icr = np.where(ifree == i)[0][0]
+      # Format each CR as '(lo1, hi1) U (lo2, hi2) U ... U (lon, hin)'
+      creg.append([' U '.join(['(' + \
+                               ', '.join(["{:10.4e}".format(CR[icr][j][k][l]) 
+                  for l in range(len(CR[icr][j][k]))]) + ')'
+                  for k in range(len(CR[icr][j]))]) 
+                  for j in range(len(CR[icr]))])
     elif i in ishare: # Shared value
       snr  = "[share{:02d}]".format(-int(stepsize[i]))
+      creg.append('') # No CRs for shared values
     else:             # Fixed value
       snr  = "[fixed]"
       mean = "{: 11.4e}".format(bestp[i])
-    log.msg("{:<11s} {:11.4e} {:>11s} {:>11s} {:>11s} {:10.4e} {:>9s}".
-            format(pnames[i][0:11], bestp[i], lo, hi, mean, stdp[i], snr),
+      creg.append('') # No CRs for fixed values
+    # Print all info except CRs
+    log.msg("{:<11s} {:11.4e} {:>11s} {:10.4e} {:>9s}".
+            format(pnames[i][0:11], bestp[i], mean, stdp[i], snr),
             width=160)
-
+  # Print CRs
+  log.msg("\nParam name  Credible Region"
+          "\n----------- "
+          "------------------------------------------------------------------", 
+          width=80)
+  for i in ifree:
+    for p in range(len(percentile)):
+      # If more than 2 disconnected regions, split it into multiple lines
+      numlines = int(np.ceil((creg[i][p].count(' U ') + 1) / 2.))
+      for r in range(numlines):
+        if p == 0 and r == 0:
+          if numlines == 1:
+            log.msg("{:<11s} {:>6s}%: {:<56s}".
+                    format(pnames[i][0:11], str(100*percentile[p]), 
+                           ' U '.join(creg[i][p].split(' U ')[:2])),
+                    width=80)
+          else:
+            log.msg("{:<11s} {:>6s}%: {:<56s}".
+                    format(pnames[i][0:11], str(100*percentile[p]), 
+                           ' U '.join(creg[i][p].split(' U ')[:2]) + ' U'),
+                    width=80)
+        elif r == 0:
+          if numlines == 1:
+            log.msg("{:<11s} {:>6s}%: {:<56s}".
+                    format("",              str(100*percentile[p]), 
+                           ' U '.join(creg[i][p].split(' U ')[:2])),
+                    width=80)
+          else:
+            log.msg("{:<11s} {:>6s}%: {:<56s}".
+                    format("",              str(100*percentile[p]), 
+                           ' U '.join(creg[i][p].split(' U ')[:2]) + ' U'),
+                    width=80)
+        else:
+          if r == numlines-1:
+            log.msg("{:<11s} {:>6s}   {:<56s}".
+                    format("", "", 
+                           ' U '.join(creg[i][p].split(' U ')[2*r:2*r+2])),
+                    width=80)
+          else:
+            log.msg("{:<11s} {:>6s}   {:<56s}".
+                    format("", "", 
+                           ' U '.join(creg[i][p].split(' U ')[2*r:2*r+2]) + ' U'),
+                    width=80)
   if leastsq and bestchisq.value-fitchisq < -3e-8:
     np.set_printoptions(precision=8)
     log.warning("MCMC found a better fit than the minimizer:\n"
@@ -680,7 +726,7 @@ def mcmc(data,          uncert=None,    func=None,      indparams=[],
   # Save definitive results:
   if savefile is not None:
     np.savez(savefile, bestp=bestp, Z=Z, Zchain=Zchain, Zchisq=Zchisq,
-             CRlo=CRlo, CRhi=CRhi, stdp=stdp, meanp=meanp,
+             CR=creg, stdp=stdp, meanp=meanp,
              bestchisq=bestchisq.value, redchisq=redchisq, chifactor=chifactor,
              BIC=BIC, sdr=sdr, numaccept=numaccept.value)
   #if savemodel is not None:
@@ -714,10 +760,10 @@ def mcmc(data,          uncert=None,    func=None,      indparams=[],
     # Histograms:
     mp.histogram(posterior, pnames=texnames[ifree], bestp=bestfreepars,
         savefile=fname+"_posterior.png",
-        percentile=0.683, pdf=pdf, xpdf=xpdf)
+        CR=CR, pdf=pdf, xpdf=xpdf)
     # RMS vs bin size:
     if rms:
-      mp.RMS(bs, RMS, stderr, RMSlo, RMShi, binstep=len(bs)//500+1,
+      mp.RMS(bs, RMS, stderr, RMSlo, RMShi, binstep=len(bs)//500 + 1,
              savefile=fname+"_RMS.png")
     # Sort of guessing that indparams[0] is the X array for data as in y=y(x):
     if (indparams != [] and
@@ -734,7 +780,7 @@ def mcmc(data,          uncert=None,    func=None,      indparams=[],
     log.close()
 
   # Build the output tuple:
-  output = bestp, CRlo, CRhi, stdp
+  output = bestp, creg, stdp
 
   if full_output:
     output += (Z, Zchain)

--- a/MCcubed/utils/mcutils.py
+++ b/MCcubed/utils/mcutils.py
@@ -253,7 +253,9 @@ def isfile(input, iname, log, dtype, unpack=True, notnone=False):
     return load(ifile)
 
 
-def credregion(posterior=None, percentile=0.6827, pdf=None, xpdf=None):
+def credregion(posterior= None,        percentile= [0.6827, 0.9545], 
+               pdf      = None,        xpdf      = None, 
+               lims     = (None,None), numpts    = 200):
   """
   Compute a smoothed posterior density distribution and the minimum
   density for a given percentile of the highest posterior density.
@@ -264,13 +266,18 @@ def credregion(posterior=None, percentile=0.6827, pdf=None, xpdf=None):
   ----------
   posterior: 1D float ndarray
      A posterior distribution.
-  percentile: Float
+  percentile: 1D float ndarray, list, or float.
      The percentile (actually the fraction) of the credible region.
      A value in the range: (0, 1).
   pdf: 1D float ndarray
      A smoothed-interpolated PDF of the posterior distribution.
   xpdf: 1D float ndarray
      The X location of the pdf values.
+  lims: tuple, floats
+     Minimum and maximum allowed values for posterior. Should only be used if 
+     there are physically-imposed limits.
+  numpts: int.
+     Number of points to use when calculating the PDF.
 
   Returns
   -------
@@ -278,8 +285,12 @@ def credregion(posterior=None, percentile=0.6827, pdf=None, xpdf=None):
      A smoothed-interpolated PDF of the posterior distribution.
   xpdf: 1D float ndarray
      The X location of the pdf values.
-  HPDmin: Float
-     The minimum density in the percentile-HPD region.
+  regions: list of 2D float ndarrays
+     The values of the credible regions specified by `percentile`.
+     regions[0] corresponds to percentile[0], etc.
+     regions[0][0] gives the start and stop values of the first region of the CR
+     regions[0][1] gives the second CR start/stop values, if the CR is composed 
+                   of disconnected regions
 
   Example
   -------
@@ -294,34 +305,52 @@ def credregion(posterior=None, percentile=0.6827, pdf=None, xpdf=None):
   >>> pdf, xpdf, HPDmin = credregion(pdf=pdf, xpdf=xpdf, percentile=0.9545)
   >>> print(np.amin(xpdf[pdf>HPDmin]), np.amax(xpdf[pdf>HPDmin]))
   """
+  # Make sure `percentile` is a list or array
+  if type(percentile) == float:
+    percentile = np.array([percentile])
   if pdf is None and xpdf is None:
-    # Thin if posterior has too many samples (> 120k):
-    thinning = np.amax([1, int(np.size(posterior)/120000)])
     # Compute the posterior's PDF:
-    kernel = stats.gaussian_kde(posterior[::thinning])
-    # Remove outliers:
-    mean = np.mean(posterior)
-    std  = np.std(posterior)
-    k = 6
-    lo = np.amax([mean-k*std, np.amin(posterior)])
-    hi = np.amin([mean+k*std, np.amax(posterior)])
+    kernel = stats.gaussian_kde(posterior)
     # Use a Gaussian kernel density estimate to trace the PDF:
-    x  = np.linspace(lo, hi, 100)
     # Interpolate-resample over finer grid (because kernel.evaluate
     #  is expensive):
+    lo   = np.amin(posterior)
+    hi   = np.amax(posterior)
+    x    = np.linspace(lo, hi, numpts)
     f    = si.interp1d(x, kernel.evaluate(x))
-    xpdf = np.linspace(lo, hi, 3000)
+    xpdf = np.linspace(lo, hi, 100*numpts)
     pdf  = f(xpdf)
 
   # Sort the PDF in descending order:
   ip = np.argsort(pdf)[::-1]
   # Sorted CDF:
   cdf = np.cumsum(pdf[ip])
-  # Indices of the highest posterior density:
-  iHPD = np.where(cdf >= percentile*cdf[-1])[0][0]
-  # Minimum density in the HPD region:
-  HPDmin = np.amin(pdf[ip][0:iHPD])
-  return pdf, xpdf, HPDmin
+
+  # List to hold boundaries of CRs
+  # List is used because a given CR may be multiple disconnected regions
+  regions = []
+  # Find boundary for each specified percentile
+  for i in range(len(percentile)):
+    # Indices of the highest posterior density:
+    iHPD = np.where(cdf >= percentile[i]*cdf[-1])[0][0]
+    # Minimum density in the HPD region:
+    HPDmin   = np.amin(pdf[ip][0:iHPD])
+    # Find the contiguous areas of the PDF greater than or equal to HPDmin
+    HPDbool  = pdf >= HPDmin
+    idiff    = np.diff(HPDbool) # True where HPDbool changes T to F or F to T
+    iregion, = idiff.nonzero()  # Indexes of Trues. Note , because returns tuple
+    # Check boundaries
+    if HPDbool[0]:
+      iregion = np.insert(iregion, 0, -1) # This -1 is changed to 0 below when 
+    if HPDbool[-1]:                       #   correcting start index for regions
+      iregion = np.append(iregion, len(HPDbool)-1)
+    # Reshape into 2 columns of start/end indices
+    iregion.shape = (-1, 2)
+    # Add 1 to start of each region due to np.diff() functionality
+    iregion[:,0] += 1
+    regions.append(xpdf[iregion])
+
+  return pdf, xpdf, regions
 
 
 def default_parnames(npars):

--- a/examples/demo01/demo01.py
+++ b/examples/demo01/demo01.py
@@ -34,7 +34,7 @@ data   = y + error                    # Noisy data set
 params   = np.array([10.0, -2.0, 0.1])  # Initial guess of fitting params.
 stepsize = np.array([0.03, 0.03, 0.05])
 
-bestp, CRlo, CRhi, stdp, posterior, Zchain = mc3.mcmc(data, uncert,
+bestp, CR, stdp, posterior, Zchain = mc3.mcmc(data, uncert,
     func=quad, indparams=[x], params=params, stepsize=stepsize,
     nsamples=1e5, burnin=1000)
 

--- a/examples/tutorial01/tutorial01.py
+++ b/examples/tutorial01/tutorial01.py
@@ -119,7 +119,7 @@ fgamma   = 1.0  # Scale factor for DEMC's gamma jump.
 fepsilon = 0.0  # Jump scale factor for DEMC's "e" distribution
 
 # Run the MCMC:
-bestp, CRlo, CRhi, stdp, posterior, Zchain = mc3.mcmc(data=data,
+bestp, CR, stdp, posterior, Zchain = mc3.mcmc(data=data,
         uncert=uncert, func=func,  indparams=indparams,
         params=params,  pmin=pmin, pmax=pmax, stepsize=stepsize,
         prior=prior,    priorlow=priorlow,    priorup=priorup,

--- a/examples/tutorial02/tutorial02.py
+++ b/examples/tutorial02/tutorial02.py
@@ -102,7 +102,7 @@ rms   = True    # Compute the time-averaging test and plot
 
 
 # Run the MCMC:
-bestp, CRlo, CRhi, stdp, posterior, Zchain = mc3.mcmc(data=data,
+bestp, CR, stdp, posterior, Zchain = mc3.mcmc(data=data,
         func=func,  indparams=indparams,
         params=params,
         walk=walk, nsamples=nsamples,  nchains=nchains,


### PR DESCRIPTION
I've updated the CR function to work for any number of regions and any number of percentiles. Output displays CRs as (region1lo, region1hi) U (region2lo, region2hi) U ... in a nice format (respects 80-character width). The code to do so is perhaps less than ideal (nested loops), but performance-wise the cost of that is minimal and it works. Plots display each requested CR, where darkest is the lowest percentile (e.g., 68% interval would be a dark grey, and 95% interval would be a light grey). Defaults to both 68% and 95% intervals, as non-Gaussian posteriors need more than 1 CR to properly interpret the results.

Let me know if there are any desired changes before you merge this into master.